### PR TITLE
Hide social media button

### DIFF
--- a/src/assets/data/heroes.js
+++ b/src/assets/data/heroes.js
@@ -138,5 +138,33 @@ module.exports = {
     picture: 'https://avatars1.githubusercontent.com/u/33497419?s=460&v=4',
     github: 'https://github.com/williamegomez',
     twitter: 'https://twitter.com/williamgomex'
+  },
+  dbotia: {
+    name: 'Diego José Luis Botia',
+    bio: 'Jefe del Departamento de Ingeniería de Sistemas de la UdeA',
+    picture: 'https://avatars1.githubusercontent.com/u/8139619?s=460&v=4',
+    github: 'https://github.com/dbotia',
+    twitter: 'https://twitter.com/djlbv'
+  },
+  moralesbang: {
+    name: 'Juan Camilo Morales',
+    bio: 'Desarrollador Ruby on Rails y React',
+    picture: 'https://avatars2.githubusercontent.com/u/22043902?s=460&v=4',
+    github: 'https://github.com/moralesbang',
+    twitter: 'https://twitter.com/moralesbang'
+  },
+  joh95: {
+    name: 'Johan Ospina Hincapié',
+    bio: 'Estudiante de Ingeniería de sistemas ',
+    picture: 'https://avatars2.githubusercontent.com/u/38740217?s=460&v=4',
+    github: 'https://github.com/joh95',
+    twitter: ''
+  },
+  breakermoob: {
+    name: 'Leon Dario Arango Amaya',
+    bio: '¡Me dedico a ver, entender e intentar cambiar el mundo!',
+    picture: 'https://avatars0.githubusercontent.com/u/26335558?s=460&v=4',
+    github: 'https://github.com/breakermoob',
+    twitter: ''
   }
 }

--- a/src/components/hero-card.vue
+++ b/src/components/hero-card.vue
@@ -7,10 +7,10 @@
       <p class="hero-card__name">{{hero.name}}</p>
       <p class="hero-card__bio">{{hero.bio}}</p>
       <div class="hero-card__social">
-        <a :href="hero.twitter">
+        <a v-if="hero.twitter" :href="hero.twitter">
           <i class="fa fa-twitter" aria-hidden="true"></i>
         </a>
-        <a :href="hero.github">
+        <a v-if="hero.github" :href="hero.github">
           <i class="fa fa-github" aria-hidden="true"></i>
         </a>
       </div>

--- a/src/components/team-card.vue
+++ b/src/components/team-card.vue
@@ -11,10 +11,10 @@
         {{teamMember.bio}}
       </p>
       <div class="team-card-social">
-        <a v-bind:href="teamMember.github">
+        <a v-if="teamMember.github" v-bind:href="teamMember.github">
           <i class="fa fa-2x fa-github" aria-hidden="true"></i>
         </a>
-        <a v-bind:href="teamMember.twitter">
+        <a v-if="teamMember.twitter" v-bind:href="teamMember.twitter">
           <i class="fa fa-2x fa-twitter" aria-hidden="true"></i>
         </a>
       </div>


### PR DESCRIPTION
## Description :black_nib:

Se oculta los enlaces de las redes sociales, cual el perfil no cuenta con estos.

Fixes # (issue)
Botones de redes sociales se mostraban cuando un perfil no tenia el link, y este quedaba con un enlace self al mismo sitio.

### Type of change :bomb:

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)